### PR TITLE
Fix UnicodeEncodeError

### DIFF
--- a/wikipedia-crawler.py
+++ b/wikipedia-crawler.py
@@ -80,7 +80,7 @@ def scrap(base_url, article, output_file, session_file):
 
     # get plain text from each <p>
     p_list = content.find_all('p')
-    with open(output_file, 'a') as fout:
+    with open(output_file, 'a', encoding='utf-8') as fout:
         for p in p_list:
             text = p.get_text().strip()
             text = parenthesis_regex.sub('', text)


### PR DESCRIPTION
writing files in
` with open(output_file, 'a') as fout:`
led frequently (depending on the wikipedia page in question) to the following error:
`UnicodeEncodeError: 'charmap' codec can't encode character '\u2032' in position 495: character maps to <undefined>
`
By specifiying the encoding (`='utf-8'`) this is fixed.